### PR TITLE
Add typescript annotation for clone function in createWithCustomClone

### DIFF
--- a/src/app/core/model/model.service.ts
+++ b/src/app/core/model/model.service.ts
@@ -34,7 +34,7 @@ export class ModelFactory<T> {
     return new Model<T>(initialData, false);
   }
 
-  createWithCustomClone(initialData: T, clone) {
+  createWithCustomClone(initialData: T, clone: (data: T) => T) {
     return new Model<T>(initialData, true, clone);
   }
 


### PR DESCRIPTION
I think that you miss to include the function signature for clone in ```createWithCustomClone```, without specifying it someone can pass "any"-thing to this constructor helper and break the Model<T> internals.